### PR TITLE
    git checkouts fail with 'unable to connect to github.com'

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,5 +2,6 @@ FROM node:8
 WORKDIR /usr/src/realtimewebclient
 COPY package.json .
 COPY yarn.lock .
+RUN git config --global url.https://.insteadOf git://
 RUN yarn install && yarn cache clean
 CMD npm run dev


### PR DESCRIPTION
Running the instructions in the repo fails with:

    Command: git
    Arguments: ls-remote --tags --heads git://github.com/shahata/jsdelivr-cdn-data.git
    Directory: /usr/src/realtimewebclient
    Output:
    fatal: unable to connect to github.com:
    github.com[0: 140.82.112.3]: errno=Connection timed out

which can be fixed by using https instead of git protocol.

It seems related to https://github.com/yarnpkg/yarn/issues/6081.